### PR TITLE
Landuse V2: Condense copying of means and timers into a common subroutine

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -3951,5 +3951,6 @@ contains
        enddo
     end if
 
+ end subroutine CopyPatchMeansTimers
 
  end module EDPatchDynamicsMod

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -3932,15 +3932,5 @@ contains
        enddo
     end if
 
-  ! =====================================================================================
-
- subroutine newsub(dp, rp)
-
-    ! !DESCRIPTION:
-    !
-    ! !ARGUMENTS:
-    type (fates_patch_type) , pointer :: dp                ! Donor Patch
-    type (fates_patch_type) , target, intent(inout) :: rp  ! Recipient Patch
-
 
  end module EDPatchDynamicsMod

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1411,7 +1411,7 @@ contains
                 buffer_patch%tallest  => null()
                 buffer_patch%shortest => null()
 
-                call CopyPatchMeansTimers(buffer_patch, currentPatch)
+                call CopyPatchMeansTimers(buffer_patch, copyPatch)
 
                 ! make a note that this buffer patch has not been put into the linked list
                 buffer_patch_in_linked_list = .false.

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -764,7 +764,7 @@ contains
                                currentPatch%burnt_frac_litter(:) = 0._r8
                             end if
 
-                            call CopyPatchMeansTimers(newPatch, currentPatch)
+                            call CopyPatchMeansTimers(currentPatch, newPatch)
 
                             call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis)
 
@@ -1411,7 +1411,7 @@ contains
                 buffer_patch%tallest  => null()
                 buffer_patch%shortest => null()
 
-                call CopyPatchMeansTimers(buffer_patch, copyPatch)
+                call CopyPatchMeansTimers(copyPatch, buffer_patch)
 
                 ! make a note that this buffer patch has not been put into the linked list
                 buffer_patch_in_linked_list = .false.
@@ -1654,7 +1654,7 @@ contains
     new_patch%tallest  => null()
     new_patch%shortest => null()
 
-    call CopyPatchMeansTimers(new_patch, currentPatch)
+    call CopyPatchMeansTimers(currentPatch, new_patch)
 
     call TransLitterNewPatch( currentSite, currentPatch, new_patch, currentPatch%area * (1.-fraction_to_keep))
 
@@ -3934,8 +3934,8 @@ contains
     ! --------------------------------------------------------------------------
     !
     ! !ARGUMENTS:
-    type (fates_patch_type) , pointer :: dp                ! Donor Patch
-    type (fates_patch_type) , target, intent(inout) :: rp  ! Recipient Patch
+    type (fates_patch_type), intent(in)    :: dp  ! Donor Patch
+    type (fates_patch_type), intent(inout) :: rp  ! Recipient Patch
 
     ! LOCAL:
     integer :: ipft   ! pft index

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -744,8 +744,6 @@ contains
 
                             call CopyPatchMeansTimers(newPatch, currentPatch)
 
-                            call newPatch%tveg_longterm%CopyFromDonor(currentPatch%tveg_longterm)
-
                             call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis)
 
                             ! Transfer in litter fluxes from plants in various contexts of death and destruction

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -774,24 +774,7 @@ contains
                                call endrun(msg=errMsg(sourcefile, __LINE__))
                             end select
 
-
-                            ! Copy any means or timers from the original patch to the new patch
-                            ! These values will inherit all info from the original patch
-                            ! --------------------------------------------------------------------------
-                            call newPatch%tveg24%CopyFromDonor(currentPatch%tveg24)
-                            call newPatch%tveg_lpa%CopyFromDonor(currentPatch%tveg_lpa)
-                            call newPatch%tveg_longterm%CopyFromDonor(currentPatch%tveg_longterm)
-
-
-                            if ( regeneration_model == TRS_regeneration ) then
-                               call newPatch%seedling_layer_par24%CopyFromDonor(currentPatch%seedling_layer_par24)
-                               call newPatch%sdlng_mort_par%CopyFromDonor(currentPatch%sdlng_mort_par)
-                               call newPatch%sdlng2sap_par%CopyFromDonor(currentPatch%sdlng2sap_par)
-                               do pft = 1,numpft
-                                  call newPatch%sdlng_emerg_smp(pft)%p%CopyFromDonor(currentPatch%sdlng_emerg_smp(pft)%p)
-                                  call newPatch%sdlng_mdd(pft)%p%CopyFromDonor(currentPatch%sdlng_mdd(pft)%p)
-                               enddo
-                            end if
+                            call CopyPatchMeansTimers(newPatch, currentPatch)
 
                             call newPatch%tveg_longterm%CopyFromDonor(currentPatch%tveg_longterm)
 
@@ -1410,22 +1393,8 @@ contains
                 buffer_patch%tallest  => null()
                 buffer_patch%shortest => null()
 
-                ! Copy any means or timers from the original patch to the new patch
-                ! These values will inherit all info from the original patch
-                ! --------------------------------------------------------------------------
-                call buffer_patch%tveg24%CopyFromDonor(copyPatch%tveg24)
-                call buffer_patch%tveg_lpa%CopyFromDonor(copyPatch%tveg_lpa)
-                call buffer_patch%tveg_longterm%CopyFromDonor(copyPatch%tveg_longterm)
+                call CopyPatchMeansTimers()
 
-                if ( regeneration_model == TRS_regeneration ) then
-                   call buffer_patch%seedling_layer_par24%CopyFromDonor(copyPatch%seedling_layer_par24)
-                   call buffer_patch%sdlng_mort_par%CopyFromDonor(copyPatch%sdlng_mort_par)
-                   call buffer_patch%sdlng2sap_par%CopyFromDonor(copyPatch%sdlng2sap_par)
-                   do pft = 1,numpft
-                      call buffer_patch%sdlng_emerg_smp(pft)%p%CopyFromDonor(copyPatch%sdlng_emerg_smp(pft)%p)
-                      call buffer_patch%sdlng_mdd(pft)%p%CopyFromDonor(copyPatch%sdlng_mdd(pft)%p)
-                   enddo
-                end if
                 buffer_patch_used = .false.
 
                 currentPatch => currentSite%oldest_patch
@@ -1669,23 +1638,8 @@ contains
     new_patch%tallest  => null()
     new_patch%shortest => null()
 
-    ! Copy any means or timers from the original patch to the new patch
-    ! These values will inherit all info from the original patch
-    ! --------------------------------------------------------------------------
-    call new_patch%tveg24%CopyFromDonor(currentPatch%tveg24)
-    call new_patch%tveg_lpa%CopyFromDonor(currentPatch%tveg_lpa)
-    call new_patch%tveg_longterm%CopyFromDonor(currentPatch%tveg_longterm)
+    call CopyPatchMeansTimers(new_patch, currentPatch)
 
-    if ( regeneration_model == TRS_regeneration ) then
-       call new_patch%seedling_layer_par24%CopyFromDonor(currentPatch%seedling_layer_par24)
-       call new_patch%sdlng_mort_par%CopyFromDonor(currentPatch%sdlng_mort_par)
-       call new_patch%sdlng2sap_par%CopyFromDonor(currentPatch%sdlng2sap_par)
-       do pft = 1,numpft
-          call new_patch%sdlng_emerg_smp(pft)%p%CopyFromDonor(currentPatch%sdlng_emerg_smp(pft)%p)
-          call new_patch%sdlng_mdd(pft)%p%CopyFromDonor(currentPatch%sdlng_mdd(pft)%p)
-       enddo
-    end if
-                            
     currentPatch%burnt_frac_litter(:) = 0._r8
     call TransLitterNewPatch( currentSite, currentPatch, new_patch, currentPatch%area * (1.-fraction_to_keep))
 
@@ -3952,5 +3906,28 @@ contains
     end if
 
  end subroutine InsertPatch
+
+  ! =====================================================================================
+
+ subroutine CopyPatchMeansTimers(bufferPatch, currentPatch)
+
+   type(fates_patch_type), intent(inout) :: bufferPatch, currentPatch
+
+   ! Copy any means or timers from the original patch to the new patch
+   ! These values will inherit all info from the original patch
+   ! --------------------------------------------------------------------------
+   call bufferPatch%tveg24%CopyFromDonor(currentPatch%tveg24)
+   call bufferPatch%tveg_lpa%CopyFromDonor(currentPatch%tveg_lpa)
+   call bufferPatch%tveg_longterm%CopyFromDonor(currentPatch%tveg_longterm)
+
+   if ( regeneration_model == TRS_regeneration ) then
+      call bufferPatch%seedling_layer_par24%CopyFromDonor(currentPatch%seedling_layer_par24)
+      call bufferPatch%sdlng_mort_par%CopyFromDonor(currentPatch%sdlng_mort_par)
+      call bufferPatch%sdlng2sap_par%CopyFromDonor(currentPatch%sdlng2sap_par)
+      do pft = 1,numpft
+         call bufferPatch%sdlng_emerg_smp(pft)%p%CopyFromDonor(currentPatch%sdlng_emerg_smp(pft)%p)
+         call bufferPatch%sdlng_mdd(pft)%p%CopyFromDonor(currentPatch%sdlng_mdd(pft)%p)
+      enddo
+   end if
 
  end module EDPatchDynamicsMod

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1621,8 +1621,8 @@ contains
     !
     ! !ARGUMENTS:
     type(ed_site_type),intent(inout) :: currentSite
-    type(fates_patch_type) , intent(inout), target :: currentPatch   ! Donor Patch
-    type(fates_patch_type) , intent(inout), target :: new_patch      ! New Patch
+    type(fates_patch_type) , intent(inout), pointer :: currentPatch   ! Donor Patch
+    type(fates_patch_type) , intent(inout), pointer :: new_patch      ! New Patch
     real(r8), intent(in)    :: fraction_to_keep  ! fraction of currentPatch to keep, the rest goes to newpatch
     !
     ! !LOCAL VARIABLES:
@@ -3937,6 +3937,9 @@ contains
     type (fates_patch_type) , pointer :: dp                ! Donor Patch
     type (fates_patch_type) , target, intent(inout) :: rp  ! Recipient Patch
 
+    ! LOCAL:
+    integer :: ipft   ! pft index
+
     call rp%tveg24%CopyFromDonor(dp%tveg24)
     call rp%tveg_lpa%CopyFromDonor(dp%tveg_lpa)
     call rp%tveg_longterm%CopyFromDonor(dp%tveg_longterm)
@@ -3945,9 +3948,9 @@ contains
        call rp%seedling_layer_par24%CopyFromDonor(dp%seedling_layer_par24)
        call rp%sdlng_mort_par%CopyFromDonor(dp%sdlng_mort_par)
        call rp%sdlng2sap_par%CopyFromDonor(dp%sdlng2sap_par)
-       do pft = 1,numpft
-          call rp%sdlng_emerg_smp(pft)%p%CopyFromDonor(dp%sdlng_emerg_smp(pft)%p)
-          call rp%sdlng_mdd(pft)%p%CopyFromDonor(dp%sdlng_mdd(pft)%p)
+       do ipft = 1,numpft
+          call rp%sdlng_emerg_smp(ipft)%p%CopyFromDonor(dp%sdlng_emerg_smp(ipft)%p)
+          call rp%sdlng_mdd(ipft)%p%CopyFromDonor(dp%sdlng_mdd(ipft)%p)
        enddo
     end if
 


### PR DESCRIPTION
While reviewing the code, particularly the new section handling splitting and fusing patches, I tried to condense some simple patterns together into a new subroutine to make future updates a little easier.  

This is just my first crack and there may be other items that could be condensed to avoid code duplication.  Please feel free to change/update this as you see fit.

**Note:** this is untested.  I need to check that builds and it's b4b.