### PR TITLE
Refactor pft area normalization to avoid checking sumarea in pft loop

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -568,13 +568,12 @@ contains
              do i_landusetype = 1, n_landuse_cats
                 sumarea = sum(sites(s)%area_pft(1:numpft,i_landusetype))
                 if(sumarea.gt.nearzero)then
-                   do ft =  1,numpft
-                      sites(s)%area_pft(ft, i_landusetype) = sites(s)%area_pft(ft, i_landusetype)/sumarea
-                   end do !ft
+                      sites(s)%area_pft(:, i_landusetype) = sites(s)%area_pft(:, i_landusetype)/sumarea
                 else
                    ! if no PFT area in primary lands, set bare ground fraction to one.
                    if ( i_landusetype .eq. primaryland) then
                       sites(s)%area_bareground = 1._r8
+                      sites(s)%area_pft(:, i_landusetype) = 0._r8
                    endif
                 end if
              end do

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -566,7 +566,7 @@ contains
              ! re-normalize PFT area to ensure it sums to one for each (active) land use type
              ! for nocomp cases, track bare ground area as a separate quantity
              do i_landusetype = 1, n_landuse_cats
-                sumarea = sum(sites(s)%area_pft(1:numpft,i_landusetype))
+                sumarea = sum(sites(s)%area_pft(:,i_landusetype))
                 if(sumarea.gt.nearzero)then
                       sites(s)%area_pft(:, i_landusetype) = sites(s)%area_pft(:, i_landusetype)/sumarea
                 else

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -567,16 +567,16 @@ contains
              ! for nocomp cases, track bare ground area as a separate quantity
              do i_landusetype = 1, n_landuse_cats
                 sumarea = sum(sites(s)%area_pft(1:numpft,i_landusetype))
-                do ft =  1,numpft
-                   if(sumarea.gt.nearzero)then
+                if(sumarea.gt.nearzero)then
+                   do ft =  1,numpft
                       sites(s)%area_pft(ft, i_landusetype) = sites(s)%area_pft(ft, i_landusetype)/sumarea
-                   else
-                      ! if no PFT area in primary lands, set bare ground fraction to one.
-                      if ( i_landusetype .eq. primaryland) then
-                         sites(s)%area_bareground = 1._r8
-                      endif
-                   end if
-                end do !ft
+                   end do !ft
+                else
+                   ! if no PFT area in primary lands, set bare ground fraction to one.
+                   if ( i_landusetype .eq. primaryland) then
+                      sites(s)%area_bareground = 1._r8
+                   endif
+                end if
              end do
                 
           end if !fixed biogeog


### PR DESCRIPTION
Simplifying the calculation and making sure that primaryland pft areas are exactly zero when everything should be bareground.