### PR TITLE
Convert an array index from real to int, satisfing nag compiler

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -482,7 +482,7 @@ contains
                          end do !hlm_pft
                       else
                          ! for crops, we need to use different logic because the bc_in(s)%pft_areafrac_lu() information only exists for natural PFTs
-                         sites(s)%area_pft(int(crop_lu_pft_vector(i_landusetype)),i_landusetype) = 1._r8
+                         sites(s)%area_pft(crop_lu_pft_vector(i_landusetype),i_landusetype) = 1._r8
                       endif
                    end do
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -482,7 +482,7 @@ contains
                          end do !hlm_pft
                       else
                          ! for crops, we need to use different logic because the bc_in(s)%pft_areafrac_lu() information only exists for natural PFTs
-                         sites(s)%area_pft(crop_lu_pft_vector(i_landusetype),i_landusetype) = 1._r8
+                         sites(s)%area_pft(int(crop_lu_pft_vector(i_landusetype)),i_landusetype) = 1._r8
                       endif
                    end do
 

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -260,7 +260,7 @@ integer, parameter, public :: maxpft = 16      ! maximum number of PFTs allowed
    integer, public :: maxpatch_total
 
    ! which crops can be grown on a given crop land use type
-   real(r8),protected,public :: crop_lu_pft_vector(n_landuse_cats)
+   integer,protected,public :: crop_lu_pft_vector(n_landuse_cats)
 
    ! Maximum allowable cohorts per patch
    integer, protected, public :: max_cohort_per_patch


### PR DESCRIPTION
### Description:
I'm working on a CTSM version compatible with the `luh2_nocomp_merge` branch, and I decided to run it through the `nag` compiler we use for testing. I got one error, about an array index not being an integer. This one-line change fixes it.

### Collaborators:
None

### Expectation of Answer Changes:
None

### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided