### PR TITLE
use site_cmass for nbp output bcs

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1070,7 +1070,7 @@ contains
                                           currentSite%mass_balance(el)%burn_flux_to_atm + &
                                           leaf_burn_frac * leaf_m * nc%n
 
-                                     ! This diagnostic only tracks
+                                     ! This term increments the loss flux from surviving trees
                                      currentSite%flux_diags%elem(el)%burned_liveveg = &
                                           currentSite%flux_diags%elem(el)%burned_liveveg + & 
                                           leaf_burn_frac * leaf_m * nc%n * area_inv
@@ -1080,12 +1080,6 @@ contains
 
                                   ! Add burned leaf carbon to the atmospheric carbon flux
                                   ! for burning.
-                                  ! [frac/day]*[kgC/plant]*[plant/ha]*[m2/ha]*[day/s] = [kg/m2/s] 
-                                  !bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
-                                  !     leaf_burn_frac * nc%prt%GetState(leaf_organ, carbon12_element) * &
-                                  !     nc%n * ha_per_m2 * days_per_sec
-                                  
-                                  ! Here the mass is removed from the plant
 
                                   if(int(prt_params%woody(currentCohort%pft)) == itrue)then
                                      call PRTBurnLosses(nc%prt, leaf_organ, leaf_burn_frac)
@@ -2002,12 +1996,7 @@ contains
 
           site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-          !if(element_list(el) == carbon12_element) then
-          !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
-          !end if
-
           ! Transfer below ground CWD (none burns)
-          
           do sl = 1,currentSite%nlevsoil
              donatable_mass         = curr_litt%bg_cwd(c,sl) * patch_site_areadis
              new_litt%bg_cwd(c,sl)  = new_litt%bg_cwd(c,sl) + donatable_mass*donate_m2
@@ -2035,10 +2024,6 @@ contains
            
            site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-           !if(element_list(el) == carbon12_element) then
-           !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
-           !end if
-           
            ! Transfer root fines (none burns)
            do sl = 1,currentSite%nlevsoil
                donatable_mass = curr_litt%root_fines(dcmpy,sl) * patch_site_areadis             
@@ -2250,10 +2235,6 @@ contains
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-             !if(element_list(el) == carbon12_element) then
-             !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
-             !end if
-
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
 
@@ -2315,10 +2296,6 @@ contains
                       burned_mass = num_dead_trees * SF_val_CWD_frac_adj(c) * bstem * &
                       currentCohort%fraction_crown_burned
                       site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-
-                      !if(element_list(el) == carbon12_element) then
-                      !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
-                      !end if
                 endif
                 new_litt%ag_cwd(c) = new_litt%ag_cwd(c) + donatable_mass * donate_m2
                 curr_litt%ag_cwd(c) = curr_litt%ag_cwd(c) + donatable_mass * retain_m2
@@ -2730,7 +2707,6 @@ contains
              end do
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-             !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
@@ -2791,7 +2767,7 @@ contains
                         EDPftvarcon_inst%landusechange_frac_burned(pft)
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-                   !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+
                 else ! all other pools can end up as timber products or burn or go to litter
                    donatable_mass = donatable_mass * (1.0_r8-EDPftvarcon_inst%landusechange_frac_exported(pft)) * &
                         (1.0_r8-EDPftvarcon_inst%landusechange_frac_burned(pft))
@@ -2804,8 +2780,6 @@ contains
                         EDPftvarcon_inst%landusechange_frac_exported(pft)
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-
-                   !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
                    trunk_product_site = trunk_product_site + &
                         woodproduct_mass

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1075,10 +1075,17 @@ contains
                                           currentSite%flux_diags%elem(el)%burned_liveveg + & 
                                           leaf_burn_frac * leaf_m * nc%n * area_inv
                                      
-                                     bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
-                                          leaf_burn_frac * leaf_m * nc%n * ha_per_m2 * days_per_sec
+                                     
                                   end do
 
+                                  ! Add burned leaf carbon to the atmospheric carbon flux
+                                  ! for burning.
+                                  ! [frac/day]*[kgC/plant]*[plant/ha]*[m2/ha]*[day/s] = [kg/m2/s] 
+                                 
+                                  bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
+                                       leaf_burn_frac * nc%prt%GetState(leaf_organ, carbon12_element) * &
+                                       nc%n * ha_per_m2 * days_per_sec
+                                  
                                   ! Here the mass is removed from the plant
 
                                   if(int(prt_params%woody(currentCohort%pft)) == itrue)then

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1081,10 +1081,9 @@ contains
                                   ! Add burned leaf carbon to the atmospheric carbon flux
                                   ! for burning.
                                   ! [frac/day]*[kgC/plant]*[plant/ha]*[m2/ha]*[day/s] = [kg/m2/s] 
-                                 
-                                  bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
-                                       leaf_burn_frac * nc%prt%GetState(leaf_organ, carbon12_element) * &
-                                       nc%n * ha_per_m2 * days_per_sec
+                                  !bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
+                                  !     leaf_burn_frac * nc%prt%GetState(leaf_organ, carbon12_element) * &
+                                  !     nc%n * ha_per_m2 * days_per_sec
                                   
                                   ! Here the mass is removed from the plant
 
@@ -2003,7 +2002,9 @@ contains
 
           site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-          bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+          !if(element_list(el) == carbon12_element) then
+          !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+          !end if
 
           ! Transfer below ground CWD (none burns)
           
@@ -2034,8 +2035,10 @@ contains
            
            site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-           bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
-
+           !if(element_list(el) == carbon12_element) then
+           !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+           !end if
+           
            ! Transfer root fines (none burns)
            do sl = 1,currentSite%nlevsoil
                donatable_mass = curr_litt%root_fines(dcmpy,sl) * patch_site_areadis             
@@ -2247,7 +2250,9 @@ contains
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+             !if(element_list(el) == carbon12_element) then
+             !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+             !end if
 
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
@@ -2310,7 +2315,10 @@ contains
                       burned_mass = num_dead_trees * SF_val_CWD_frac_adj(c) * bstem * &
                       currentCohort%fraction_crown_burned
                       site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-                      bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+
+                      !if(element_list(el) == carbon12_element) then
+                      !   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+                      !end if
                 endif
                 new_litt%ag_cwd(c) = new_litt%ag_cwd(c) + donatable_mass * donate_m2
                 curr_litt%ag_cwd(c) = curr_litt%ag_cwd(c) + donatable_mass * retain_m2
@@ -2320,7 +2328,7 @@ contains
 
             currentCohort => currentCohort%taller
         enddo
-    end do
+     end do
     
     return
   end subroutine fire_litter_fluxes
@@ -2401,7 +2409,7 @@ contains
 
 
     do el = 1,num_elements
-       
+
        element_id = element_list(el)
        site_mass  => currentSite%mass_balance(el)
        elflux_diags => currentSite%flux_diags%elem(el)
@@ -2722,8 +2730,7 @@ contains
              end do
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-
-             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+             !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
@@ -2784,7 +2791,7 @@ contains
                         EDPftvarcon_inst%landusechange_frac_burned(pft)
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+                   !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
                 else ! all other pools can end up as timber products or burn or go to litter
                    donatable_mass = donatable_mass * (1.0_r8-EDPftvarcon_inst%landusechange_frac_exported(pft)) * &
                         (1.0_r8-EDPftvarcon_inst%landusechange_frac_burned(pft))
@@ -2798,7 +2805,7 @@ contains
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
+                   !!bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
                    trunk_product_site = trunk_product_site + &
                         woodproduct_mass

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -144,7 +144,8 @@ module EDPhysiologyMod
   use PRTInitParamsFatesMod, only : NewRecruitTotalStoichiometry
   use FatesInterfaceTypesMod, only : hlm_use_luh
   use FatesInterfaceTypesMod, only : hlm_regeneration_model
-
+  
+  
   implicit none
   private
 
@@ -155,8 +156,6 @@ module EDPhysiologyMod
   public :: calculate_SP_properties
   public :: recruitment
   public :: ZeroLitterFluxes
-  public :: ZeroBCOutCarbonFluxes
-
   public :: ZeroAllocationRates
   public :: PreDisturbanceLitterFluxes
   public :: PreDisturbanceIntegrateLitter
@@ -229,20 +228,6 @@ contains
 
     return
   end subroutine ZeroLitterFluxes
-
-  ! =====================================================================================
-
-  subroutine ZeroBCOutCarbonFluxes (bc_out)
-
-    ! !ARGUMENTS
-    type(bc_out_type), intent(inout)   :: bc_out
-
-    bc_out%grazing_closs_to_atm_si = 0._r8
-    bc_out%fire_closs_to_atm_si    = 0._r8
-    bc_out%gpp_site                = 0._r8
-    bc_out%ar_site                 = 0._r8
-
-  end subroutine ZeroBCOutCarbonFluxes
 
   ! =====================================================================================
 
@@ -496,7 +481,7 @@ contains
          ! Send fluxes from newly created litter into the litter pools
          ! This litter flux is from non-disturbance inducing mortality, as well
          ! as litter fluxes from live trees
-         call CWDInput(currentSite, currentPatch, litt,bc_in, bc_out)
+         call CWDInput(currentSite, currentPatch, litt,bc_in)
          
          ! Only calculate fragmentation flux over layers that are active
          ! (RGK-Mar2019) SHOULD WE MAX THIS AT 1? DONT HAVE TO
@@ -2803,7 +2788,7 @@ contains
 
    ! ======================================================================================
 
-  subroutine CWDInput( currentSite, currentPatch, litt, bc_in, bc_out)
+  subroutine CWDInput( currentSite, currentPatch, litt, bc_in)
 
     !
     ! !DESCRIPTION:
@@ -2823,7 +2808,6 @@ contains
     type(fates_patch_type),intent(inout), target :: currentPatch
     type(litter_type),intent(inout),target    :: litt
     type(bc_in_type),intent(in)               :: bc_in
-    type(bc_out_type),intent(inout)           :: bc_out
 
     !
     ! !LOCAL VARIABLES:
@@ -2976,10 +2960,6 @@ contains
        site_mass%herbivory_flux_out = &
             site_mass%herbivory_flux_out + &
             leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n
-
-       bc_out%grazing_closs_to_atm_si = bc_out%grazing_closs_to_atm_si + &
-            leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n * &
-            ha_per_m2 * days_per_sec
 
        ! Assumption: turnover from deadwood and sapwood are lumped together in CWD pool
 

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -842,6 +842,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     type (fates_patch_type) , pointer :: currentPatch
+    type(site_massbal_type), pointer :: site_cmass
     real(r8) :: total_stock  ! dummy variable for receiving from sitemassstock
     !-----------------------------------------------------------------------
 
@@ -920,8 +921,8 @@ contains
 
     ! Set boundary condition to HLM for carbon loss to atm from fires
     ! [kgC/ha/day]*[m2/ha]*[day/s] = [kg/m2/s] 
-    site_mass => currentSite%mass_balance(element_pos(carbon12_element))
-    bc_out%fire_closs_to_atm_si = site_mass%burn_flux_to_atm * ha_per_m2 * days_per_sec
+    site_cmass => currentSite%mass_balance(element_pos(carbon12_element))
+    bc_out%fire_closs_to_atm_si = site_cmass%burn_flux_to_atm * ha_per_m2 * days_per_sec
     
 
   end subroutine ed_update_site

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -918,6 +918,11 @@ contains
     bc_out%litter_cwd_c_si = bc_out%litter_cwd_c_si * g_per_kg * AREA_INV
     bc_out%seed_c_si = bc_out%seed_c_si * g_per_kg * AREA_INV
 
+    ! Set boundary condition to HLM for carbon loss to atm from fires
+    ! [kgC/ha/day]*[m2/ha]*[day/s] = [kg/m2/s] 
+    site_mass => currentSite%mass_balance(element_pos(carbon12_element))
+    bc_out%fire_closs_to_atm_si = site_mass%burn_flux_to_atm * ha_per_m2 * days_per_sec
+    
 
   end subroutine ed_update_site
 

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -27,6 +27,7 @@ module EDMainMod
   use FatesInterfaceTypesMod        , only : hlm_masterproc
   use FatesInterfaceTypesMod        , only : numpft
   use FatesInterfaceTypesMod        , only : hlm_use_nocomp
+  use FatesInterfaceTypesMod        , only : ZeroBCOutCarbonFluxes
   use PRTGenericMod            , only : prt_carbon_allom_hyp
   use PRTGenericMod            , only : prt_cnp_flex_allom_hyp
   use PRTGenericMod            , only : nitrogen_element
@@ -46,7 +47,7 @@ module EDMainMod
   use EDPhysiologyMod          , only : SeedUpdate
   use EDPhysiologyMod          , only : ZeroAllocationRates
   use EDPhysiologyMod          , only : ZeroLitterFluxes
-  use EDPhysiologyMod          , only : ZeroBCOutCarbonFluxes
+ 
   use EDPhysiologyMod          , only : PreDisturbanceLitterFluxes
   use EDPhysiologyMod          , only : PreDisturbanceIntegrateLitter
   use EDPhysiologyMod          , only : UpdateRecruitL2FR
@@ -919,11 +920,11 @@ contains
     bc_out%litter_cwd_c_si = bc_out%litter_cwd_c_si * g_per_kg * AREA_INV
     bc_out%seed_c_si = bc_out%seed_c_si * g_per_kg * AREA_INV
 
-    ! Set boundary condition to HLM for carbon loss to atm from fires
+    ! Set boundary condition to HLM for carbon loss to atm from fires and grazing
     ! [kgC/ha/day]*[m2/ha]*[day/s] = [kg/m2/s] 
     site_cmass => currentSite%mass_balance(element_pos(carbon12_element))
     bc_out%fire_closs_to_atm_si = site_cmass%burn_flux_to_atm * ha_per_m2 * days_per_sec
-    
+    bc_out%grazing_closs_to_atm_si = site_cmass%herbivory_flux_out * ha_per_m2 * days_per_sec
 
   end subroutine ed_update_site
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -371,8 +371,11 @@ contains
     end select
 
     ! carbon loss to atmosphere pathways
-    fates%bc_out(s)%grazing_closs_to_atm_si = 0.0_r8
-    fates%bc_out(s)%fire_closs_to_atm_si    = 0.0_r8
+    ! (these values are a unit conversion off of the
+    !  equivalent "site_mass%" diagnostics, so they are not
+    !  incremented but set during update_site())
+    fates%bc_out(s)%grazing_closs_to_atm_si = nan
+    fates%bc_out(s)%fire_closs_to_atm_si    = nan
 
     fates%bc_out(s)%rssun_pa(:)     = 0.0_r8
     fates%bc_out(s)%rssha_pa(:)     = 0.0_r8

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -858,10 +858,25 @@ module FatesInterfaceTypesMod
                                                 ! increasing, or all 1s)
 
    end type bc_pconst_type
-  
+
+   public :: ZeroBCOutCarbonFluxes
+   
  contains
        
-    ! ======================================================================================
-      
+   ! ======================================================================================
+
+   subroutine ZeroBCOutCarbonFluxes(bc_out)
+
+    ! !ARGUMENTS
+    type(bc_out_type), intent(inout)   :: bc_out
+
+    bc_out%grazing_closs_to_atm_si = nan    ! set via site_mass%burn_flux
+    bc_out%fire_closs_to_atm_si    = nan    ! set via site_mass%herbivory_flux_out
+    bc_out%gpp_site                = 0._r8
+    bc_out%ar_site                 = 0._r8
+
+  end subroutine ZeroBCOutCarbonFluxes
+
+   
        
-  end module FatesInterfaceTypesMod
+end module FatesInterfaceTypesMod


### PR DESCRIPTION
These changes are for the nbp bc_out refactors, this changes things so that we use the existing mass tracking site-level structures, and we don't include N and P into the carbon loss flux arrays.
